### PR TITLE
update object after saveOne only if returned

### DIFF
--- a/Pomm/Object/BaseObjectMap.php
+++ b/Pomm/Object/BaseObjectMap.php
@@ -467,7 +467,11 @@ abstract class BaseObjectMap
             $collection = $this->query($sql, array());
         }
 
-        $object = $collection->current();
+        if ($collection->count())
+        {
+            $object = $collection->current();
+        }
+
         $object->_setStatus(BaseObject::EXIST);
     }
 


### PR DESCRIPTION
when implement partitioning as http://www.postgresql.org/docs/8.1/interactive/ddl-partitioning.html, trigger returns null value to prevent duplicate insertion in both parent and children tables.
