### PR TITLE
Fixing an issue with namespace in cas of inheritance

### DIFF
--- a/Pomm/Tools/CreateBaseMapTool.php
+++ b/Pomm/Tools/CreateBaseMapTool.php
@@ -94,10 +94,21 @@ class CreateBaseMapTool extends CreateFileTool
             }
             else
             {
-                $extends = sprintf("\\%s\\%s\\%sMap", 
-                    sfInflector::camelize($this->options['database']->getName()),
-                    sfInflector::camelize($parent_table_infos['schema']),
-                    sfInflector::camelize($parent_table_infos['table']));
+                if ( $this->options['namespace'] !== '' )
+                {
+                    $extends = sprintf("\\%s\\%s\\%s\\%sMap",
+                        $this->options['namespace'],
+                        sfInflector::camelize($this->options['database']->getName()),
+                        sfInflector::camelize($parent_table_infos['schema']),
+                        sfInflector::camelize($parent_table_infos['table']));
+                }
+                else
+                {
+                    $extends = sprintf("\\%s\\%s\\%sMap",
+                        sfInflector::camelize($this->options['database']->getName()),
+                        sfInflector::camelize($parent_table_infos['schema']),
+                        sfInflector::camelize($parent_table_infos['table']));
+                }
             }
 
             $fields_definition = $this->generateFieldsDefinition(array_diff_key($this->inspector->getTableFieldsInformation($this->options['oid']), $this->inspector->getTableFieldsInformation($inherits)));


### PR DESCRIPTION
we take now into account the --prefix-namespace command line option when extending the parent map classe in case of inheritance
