### PR TITLE
Changed a use of Exception to PommException

### DIFF
--- a/Pomm/Connection/Database.php
+++ b/Pomm/Connection/Database.php
@@ -198,7 +198,7 @@ class Database
             }
             else
             {
-                throw new Exception(sprintf("Pg type '%s' is associated with converter '%s' but converter is not registered.", $pg_type, $converter_name));
+                throw new PommException(sprintf("Pg type '%s' is associated with converter '%s' but converter is not registered.", $pg_type, $converter_name));
             }
         }
 


### PR DESCRIPTION
Should likely be either \Exception or PommException.  Is PommException is intended?
If so this may need to also be fixed on master.
