### PR TITLE
convert to numbers in Pomm\Converter\PgNumber

### DIFF
--- a/Pomm/Converter/PgNumber.php
+++ b/Pomm/Converter/PgNumber.php
@@ -19,7 +19,7 @@ class PgNumber implements ConverterInterface
      **/
     public function fromPg($data, $type = null)
     {
-        return $data;
+        return $data + 0;
     }
 
     /**
@@ -27,6 +27,6 @@ class PgNumber implements ConverterInterface
      **/
     public function toPg($data, $type = null)
     {
-        return $data;
+        return $data + 0;
     }
 }


### PR DESCRIPTION
Currently if you do something like

```
$entity = $map->createObject(array('speed' => 'NOT A NUMBER'));
$map->saveOne($entity);
```

(where speed is a numeric column), then `NOT A NUMBER` gets interpolated into the SQL without escaping, and you get an error (and possibility of SQL injection).

This patch ensures that values for numeric columns get converted to numbers (so no escaping is required) before being substituted into the SQL statement.

Additionally, it now converts the values to numbers as they come out of the database also. That's not as necessary, but it can be convenient.
