### PR TITLE
Using __sleep and __desctruct before serialization

### DIFF
--- a/Pomm/Object/Collection.php
+++ b/Pomm/Object/Collection.php
@@ -18,6 +18,31 @@ class Collection extends SimpleCollection
     protected $filters = array();
     protected $fetched = array();
 
+
+    /**
+     * __sleep
+     * 
+     * clean the object before serializing it
+     * 
+     **/
+    public function __sleep()
+    {
+        return array('position', 'filters', 'fetched');
+    }
+    
+    /**
+     * __destruct 
+     * 
+     * only call the parent function if stmt is set
+     * 
+     **/
+    public function __destruct()
+    {
+        if (isset($this->stmt)) {
+    	    parent::__destruct();
+        }
+    }
+    
     /**
      * registerFilter
      *


### PR DESCRIPTION
Hi,

This is my first contribution to Pomm.

I'm using Pomm for a project and for some reason I need to serialize a Collecton of Pomm Results in a memcached instance.

To do that properly, the Collection Class need some extra function : __sleep and __destruct.

Feel free to integrate it in the main repository.

Best regards,

Nicolas.
