### PR TITLE
Using __sleep and __desctruct in collection

### DIFF
--- a/Pomm/Object/Collection.php
+++ b/Pomm/Object/Collection.php
@@ -18,6 +18,31 @@ class Collection extends SimpleCollection
     protected $filters = array();
     protected $fetched = array();
 
+
+    /**
+     * __sleep
+     * 
+     * clean the object before serializing it
+     * 
+     **/
+    public function __sleep()
+    {
+        return array('position', 'filters', 'fetched');
+    }
+    
+    /**
+     * __destruct 
+     * 
+     * only call the parent function if stmt is set
+     * 
+     **/
+    public function __destruct()
+    {
+        if (isset($this->stmt)) {
+    	    parent::__destruct();
+        }
+    }
+    
     /**
      * registerFilter
      *


### PR DESCRIPTION
Hi,

I know that you can use a custom collection class with your Pomm project, but i suggest to add theses __sleep and __descruct method in the Collection class in order to make them serializable.
