### PR TITLE
Fixed errors in BaseTool and doc; made CreateBaseMapTool 'extends' output more standard

### DIFF
--- a/Pomm/Object/BaseObject.php
+++ b/Pomm/Object/BaseObject.php
@@ -42,7 +42,7 @@ abstract class BaseObject implements \ArrayAccess, \IteratorAggregate
     /**
      * get
      *
-     * Returns the $name value
+     * Returns the $var value
      *
      * @final
      * @param String $var      Key you want to retrieve value from.
@@ -183,17 +183,27 @@ abstract class BaseObject implements \ArrayAccess, \IteratorAggregate
         $array_recurse = function($val) use (&$array_recurse)
         {
             if (is_scalar($val))
+            {
                 return $val;
+            }
+
             if (is_array($val))
             {
                 if (is_array(current($val)) || (is_object(current($val)) && current($val) instanceof BaseObject))
                 {
                     return array_map($array_recurse, $val);
                 }
-                else return $val;
+                else
+                {
+                    return $val;
+                }
             }
+
             if (is_object($val) && $val instanceof BaseObject)
+            {
                 return $val->extract();
+            }
+
             return $val;
         };
 

--- a/Pomm/Tools/BaseTool.php
+++ b/Pomm/Tools/BaseTool.php
@@ -29,13 +29,13 @@ abstract class BaseTool
     final public function __construct(Array $options = array())
     {
         $this->options = new ParameterHolder($options);
-        $this->output_stack = new OutputLineStack($this->options->hasParameter('output_level') ? $this->options->get('output_level') : OutputLine::LEVEL_ALL);
+        $this->output_stack = new OutputLineStack($this->options->hasParameter('output_level') ? $this->options->getParameter('output_level') : OutputLine::LEVEL_ALL);
 
         $this->configure();
     }
 
     /**
-     * configure 
+     * configure
      *
      * This is called from the constructor. Override it to
      * configure the parameter holder.
@@ -46,7 +46,7 @@ abstract class BaseTool
     protected abstract function configure();
 
     /**
-     * execute 
+     * execute
      *
      * Is called when the tool is to be executed.
      *

--- a/Pomm/Tools/CreateBaseMapTool.php
+++ b/Pomm/Tools/CreateBaseMapTool.php
@@ -127,16 +127,20 @@ class CreateBaseMapTool extends CreateFileTool
             $parent_call = "";
         }
 
+        $extends = ltrim($extends, '\\');
+        $use_map = ($extends === 'BaseObjectMap')
+            ? "use \\Pomm\\Object\\BaseObjectMap;"
+            : "use {$extends} as BaseObjectMap;";
 
         $php = <<<EOD
 <?php
 
 namespace $namespace;
 
-use \\Pomm\\Object\\BaseObjectMap;
+$use_map
 use \\Pomm\\Exception\\Exception;
 
-abstract class $map_name extends $extends
+abstract class $map_name extends BaseObjectMap
 {
     public function initialize()
     {

--- a/documentation/documentation.html
+++ b/documentation/documentation.html
@@ -1588,7 +1588,7 @@ $this-&gt;findWhere(Pomm\Query\Where::createWhereIn("(station_id, line_no)", arr
 $where2 = new Pomm\Query\Where('age &lt; ?', array(18));
 
 $where1-&gt;orWhere($where2);
-$where1-&gt;andWhere(Pomm\Query\Where::createIn('other_id', array(1,2,3,5,7,11)));
+$where1-&gt;andWhere(Pomm\Query\Where::createWhereIn('other_id', array(1,2,3,5,7,11)));
 
 echo $where1; // (pika = ? OR age &lt; ?) AND other_id IN (?,?,?,?,?,?)
 </pre>

--- a/documentation/documentation.rst
+++ b/documentation/documentation.rst
@@ -739,7 +739,7 @@ The ``Where`` class has two very handy methods: ``andWhere`` and ``orWhere`` whi
 Because the ``WHERE something IN (...)`` clause needs to declare as many '?' as given parameters, it has its own constructor::
 
     // WHERE (station_id, line_no) IN ((1, 1), (1, 3), ... );
-    
+
     $this->findWhere(Pomm\Query\Where::createWhereIn("(station_id, line_no)", array(array(1, 1), array(1, 3)))
 
 The ``Where`` instances can be combined together with respect of the logical precedence::
@@ -748,7 +748,7 @@ The ``Where`` instances can be combined together with respect of the logical pre
     $where2 = new Pomm\Query\Where('age < ?', array(18));
 
     $where1->orWhere($where2);
-    $where1->andWhere(Pomm\Query\Where::createIn('other_id', array(1,2,3,5,7,11))); 
+    $where1->andWhere(Pomm\Query\Where::createWhereIn('other_id', array(1,2,3,5,7,11)));
 
     echo $where1; // (pika = ? OR age < ?) AND other_id IN (?,?,?,?,?,?)
 

--- a/tests/Pomm/Fixture/TestDb/PommTestProd/Base/ChuMap.php
+++ b/tests/Pomm/Fixture/TestDb/PommTestProd/Base/ChuMap.php
@@ -2,10 +2,10 @@
 
 namespace TestDb\PommTestProd\Base;
 
-use \Pomm\Object\BaseObjectMap;
+use TestDb\PommTest\PikaMap as BaseObjectMap;
 use \Pomm\Exception\Exception;
 
-abstract class ChuMap extends \\TestDb\PommTest\PikaMap
+abstract class ChuMap extends BaseObjectMap
 {
     public function initialize()
     {


### PR DESCRIPTION
I have added support for `--output-level` command option in my fork of PommBundle, but it depends on this fix here to work.

BaseTool was calling unexisting `$this->options->get(...)`. I changed it to `$this->options->getParameter(...)`.

How should I proceed with the Pull Request for PommBundle? People not using this commit of Pomm would receive an error. See akp999/PommBundle@cbec4e974ac0ae2db1a58103fe9d4caa0c254b84
