### PR TITLE
Do not treat emtpy string ('') as null

### DIFF
--- a/Pomm/Object/BaseObjectMap.php
+++ b/Pomm/Object/BaseObjectMap.php
@@ -737,7 +737,7 @@ abstract class BaseObjectMap
         $out_values = array();
         foreach ($values as $name => $value)
         {
-            if (is_null($value) or $value === '')
+            if (is_null($value))
             {
                 $out_values[$name] = null;
                 continue;


### PR DESCRIPTION
In Postgresql, there is a strong distinction between an empty string and a null.

When loading datas from the DB, the convertFromPg transform '' to a null value.

let's imagaine this : 

``` SQL
Create Table MyTBL( id serial, a text not null, b text not null);
Insert into MyTBL(1, 'Hello', '');
```

Then in Pomm

``` PHP
$map = $conn->getMapFor('\Hello\World\MyTbL');
$obj = $map->findByPk(array('id' => 1)));
$obj->setA('World');
$map->saveOne($obj);
```

This will give you and error about B violating the not null constraint

Let's change this...

what do you think? 
