### PR TITLE
createPreparedQuery factory method

### DIFF
--- a/Pomm/Connection/Connection.php
+++ b/Pomm/Connection/Connection.php
@@ -437,7 +437,7 @@ class Connection implements LoggerAwareInterface
 
         if ($this->hasQuery($signature) === false)
         {
-            $query = new PreparedQuery($this, $sql);
+            $query = $this->createPreparedQuery($sql);
             $this->queries[$query->getName()] = $query;
         }
 


### PR DESCRIPTION
The createPreparedQuery factory method is not used by getQuery. Changing this allow the developper to extend the PreparedQuery by overriding the factory method.
