### PR TITLE
Makes the json converter compatible with every kinds of types.

### DIFF
--- a/Pomm/Converter/PgJSON.php
+++ b/Pomm/Converter/PgJSON.php
@@ -3,7 +3,6 @@
 namespace Pomm\Converter;
 
 use Pomm\Converter\ConverterInterface;
-use Pomm\Exception\Exception as PommException;
 
 /**
  * Pomm\Converter\PgJSON -- JSON converter
@@ -37,21 +36,6 @@ class PgJSON implements ConverterInterface
      */
     public function toPg($data, $type = null)
     {
-        if ($this->output_type === static::OUTPUT_ARRAYS)
-        {
-            if (!is_array($data))
-            {
-                throw new PommException(sprintf("Json converter 'toPg()' with OUTPUT_ARRAYS expects data to be array. '%s' given.", gettype($data)));
-            }
-        }
-        else
-        {
-            if (!(is_object($data) or $data instanceOf \StdClass))
-            {
-                throw new PommException(sprintf("Json converter 'toPg()' with OUTPUT_OBJECTS expecte data to be instance of StdClass, '%s' given", get_class($data)));
-            }
-        }
-
         $data = json_encode($data);
         $type = is_null($type) ? '' : sprintf("%s ", $type);
         $data = sprintf("%s'%s'",  $type, $data);


### PR DESCRIPTION
The json type is more expressive and can handle scalar values too. These kind of operations became possible:

``` php
$converter->toPg(true);
$converter->toPg(pi());
$converter->toPg(null);
$converter->toPg('foo');
```
