### PR TITLE
Properly handle uninitialized connection

### DIFF
--- a/Pomm/Connection/Connection.php
+++ b/Pomm/Connection/Connection.php
@@ -113,11 +113,15 @@ class Connection implements LoggerAwareInterface
             $connect_parameters[] = sprintf('password=%s', addslashes($this->parameter_holder['pass']));
         }
 
-        $this->handler = @pg_connect(join(' ', $connect_parameters), \PGSQL_CONNECT_FORCE_NEW);
+        $handler = @pg_connect(join(' ', $connect_parameters), \PGSQL_CONNECT_FORCE_NEW);
 
-        if ($this->handler === false)
+        if ($handler === false)
         {
             $this->throwConnectionException(sprintf("Error connecting to the database with dsn '%s'.", join(' ', $connect_parameters)), LogLevel::ALERT);
+        }
+        else
+        {
+            $this->handler = $handler;
         }
 
         $sql = '';
@@ -142,7 +146,7 @@ class Connection implements LoggerAwareInterface
      */
     public function __destruct()
     {
-        if (!isset($this->handler))
+        if ($this->handler !== null)
         {
             pg_close($this->handler);
         }
@@ -158,7 +162,7 @@ class Connection implements LoggerAwareInterface
      */
     public function getHandler()
     {
-        if (!isset($this->handler))
+        if ($this->handler === null)
         {
             $this->launch();
         }

--- a/tests/Pomm/Test/Connection/ConnectionTest.php
+++ b/tests/Pomm/Test/Connection/ConnectionTest.php
@@ -44,6 +44,12 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase
         $connection->getHandler();
     }
 
+    public function testMultipleConnection()
+    {
+        $database = new Database(array('dsn' => $GLOBALS['dsn'], 'name' => 'test_db'));
+        $connection = $database->createConnection();
+    }
+
     public function testGetMapFor()
     {
         $map1 = static::$connection->getMapFor('\Pomm\Test\Connection\CnxEntity');


### PR DESCRIPTION
The initial problem, when I create a second connections:

```
Warning: pg_close() expects parameter 1 to be resource, null given in Pomm/Connection/Connection.php line 147
```

This probably silenced the real problem, but I don’t understand what happens.
