### PR TITLE
Modification to browse virtual_fields on PgRow converter when data come from postgresql

### DIFF
--- a/Pomm/Converter/PgRow.php
+++ b/Pomm/Converter/PgRow.php
@@ -191,6 +191,11 @@ class PgRow implements ConverterInterface
             $values[$field_name] = stripcslashes(array_shift($elts));
         }
 
+        foreach ($this->virtual_fields as $field_name => $type)
+        {
+            $values[$field_name] = stripcslashes(array_shift($elts));
+        }
+
         if (count($elts) > 0)
         {
             $values['_extra'] = $elts;

--- a/Pomm/Object/BaseObjectMap.php
+++ b/Pomm/Object/BaseObjectMap.php
@@ -122,6 +122,7 @@ abstract class BaseObjectMap
      */
     public function getConverter()
     {
+        $this->converter->setVirtualFields($this->virtual_fields);
         return $this->converter;
     }
 


### PR DESCRIPTION
In this case below :

``` php
    class OrderMap extends BaseOrderMap
    {
        public function findWithDetails($orderId)
        {
            $orderId = (int) $orderId;

            $this->addVirtualField('details', 'order_detail[]');

            $mapOrderDetail = $this->connection->getMapFor('OrderDetail');
            $mapOrderDetail->addVirtualField('product', 'product');

            $this->connection->getDatabase()->registerConverter(
                        'OrderDetail',
                        new \Pomm\Converter\PgEntity($mapOrderDetail),
                        array('order_detail')
                    );

            $mapProduct = $this->connection->getMapFor('Product');

            $this->connection->getDatabase()->registerConverter(
                        'Product',
                        new \Pomm\Converter\PgEntity($mapProduct),
                        array('product')
                    );

            $sql = 'WITH details AS (
                        SELECT od.*, p AS product
                        FROM :order_detail_table AS od
                        JOIN :product_table AS p
                            ON od.product_id = p.product_id
                        WHERE od.order_id = $*
                        ORDER BY od.label ASC
                    )
                    SELECT :order_alias_o,
                        array_agg(d) AS details
                    FROM :order_table AS o
                    JOIN details AS d
                        ON o.order_id = p.order_id
                    WHERE o.order_id = $*
                    GROUP BY :invoice_group_by';

            [...]
        }

    }
```

We would get `product` datas on orderDetail virtualField on primary order virtualField.
With modification on this PR it works.
